### PR TITLE
Fix: AES-256 have a bloc size of 128 bits.

### DIFF
--- a/lib/cryptcheck/tls/cipher.rb
+++ b/lib/cryptcheck/tls/cipher.rb
@@ -194,7 +194,7 @@ module CryptCheck
 					when aes128?
 						[:aes, 128, 128, self.mode]
 					when aes256?
-						[:aes, 256, 256, self.mode]
+						[:aes, 256, 128, self.mode]
 					when camellia?
 						[:camellia, 128, 128, self.mode]
 					when seed?


### PR DESCRIPTION
From https://tools.ietf.org/html/rfc5246 : 

>    Advanced Encryption Standard (AES)
>       AES [AES] is a widely used symmetric encryption algorithm.  AES is
>       a block cipher with a 128-, 192-, or 256-bit keys and a 16-byte
>       block size.  TLS currently only supports the 128- and 256-bit key
>       sizes.

Best regards,
Tosh.